### PR TITLE
fix: decode gzipped stockcharts responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,10 +266,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "debugid"
@@ -320,6 +358,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -800,6 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1605,6 +1654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,12 +1917,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 chrono-tz = "0.10"
 clap = { version = "4.5", features = ["derive", "env"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["gzip", "json", "rustls-tls"] }
 sentry = { version = "0.43", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls", "tracing"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/stockcharts.rs
+++ b/src/stockcharts.rs
@@ -148,6 +148,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_alerts_decodes_gzipped_stockcharts_payloads() {
+        const GZIPPED_ALERTS: &[u8] = &[
+            31, 139, 8, 0, 0, 0, 0, 0, 2, 255, 139, 174, 86, 74, 204, 73, 45, 42, 81, 178, 82, 114,
+            206, 207, 45, 40, 74, 45, 46, 78, 77, 81, 210, 81, 202, 73, 44, 46, 73, 203, 44, 2,
+            178, 173, 148, 140, 13, 21, 188, 74, 115, 20, 140, 12, 140, 76, 116, 20, 12, 141, 172,
+            140, 141, 11, 114, 149, 106, 99, 1, 238, 170, 40, 62, 59, 0, 0, 0,
+        ];
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/j-sum/sum")
+            .match_query(Matcher::UrlEncoded("cmd".to_string(), "alert".to_string()))
+            .with_status(200)
+            .with_header("content-encoding", "gzip")
+            .with_header("content-type", "application/json;charset=iso-8859-1")
+            .with_body(GZIPPED_ALERTS)
+            .create_async()
+            .await;
+
+        let alerts = test_client(format!("{}/j-sum/sum?cmd=alert", server.url()))
+            .get_alerts()
+            .await;
+
+        mock.assert_async().await;
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0]["alert"], "Compressed");
+    }
+
+    #[tokio::test]
     async fn get_alerts_retries_then_returns_empty() {
         let mut server = mockito::Server::new_async().await;
         let mock = server


### PR DESCRIPTION
## Summary
- Fixes the deployed Rust service failing to parse StockCharts alert responses when the endpoint returns gzip-compressed JSON.
- Keeps reqwest default features disabled, but opts into the gzip decoder needed by the live endpoint.

## Changes
- Enable reqwest's `gzip` feature.
- Add a mockito regression test for `content-encoding: gzip` StockCharts payloads.
- Update `Cargo.lock` with the required compression dependencies.

## Testing
- [x] `make all`
- [x] Verified the gzip regression test fails when the reqwest `gzip` feature is removed
- [x] Local CodeRabbit review, 0 findings
