### PR TITLE
feat: harden sentry error reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ src/
   error.rs        # thiserror error enum and Result alias
   http.rs         # shared reqwest client builder and HTTP status handling
   stockcharts.rs  # StockCharts fetch client, headers, retry behavior, JSON decoding
-  telemetry.rs    # tracing and optional Sentry initialization
+  telemetry.rs    # tracing, optional Sentry initialization, and error capture
 ```
 
 ## Architecture
@@ -37,6 +37,7 @@ Configuration comes from CLI arguments and environment variables via `clap`.
 - Webhook URLs are split, trimmed, and deduplicated during settings normalization.
 - `MINUTES_BETWEEN_RUNS` is bounded from 1 to 1440 and defaults to 5.
 - Optional Sentry and release env vars: `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `GIT_COMMIT`, `GIT_BRANCH`.
+- When `SENTRY_DSN` is configured, scheduler, application, and Discord webhook errors are captured in Sentry in addition to stdout logs. INFO logs still remain stdout-only.
 
 ### HTTP Client
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Required:
 Optional:
 
 - `MINUTES_BETWEEN_RUNS`: polling interval in minutes, from 1 to 1440. Defaults to 5.
-- `SENTRY_DSN`: enables Sentry when set.
+- `SENTRY_DSN`: enables Sentry panic, application error, and Discord webhook failure reporting when set.
 - `SENTRY_ENVIRONMENT`: defaults to `production`.
 - `GIT_COMMIT` and `GIT_BRANCH`: injected by the container build and used for the Sentry release string.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,12 +6,12 @@ use tokio::time::{Duration as TokioDuration, MissedTickBehavior, interval, sleep
 use tracing::{error, info, warn};
 
 use crate::{
-    Result, Settings,
+    Error, Result, Settings,
     alerts::{STOCKCHARTS_TIME_ZONE, new_alerts_since},
     discord::DiscordClient,
     http::build_http_client,
     stockcharts::StockChartsClient,
-    telemetry::{init_sentry, init_tracing},
+    telemetry::{capture_error, init_sentry, init_tracing},
 };
 
 const MAX_CONSECUTIVE_ERRORS: u64 = 5;
@@ -84,6 +84,7 @@ impl App {
     pub async fn run_until_shutdown(&self) -> Result<()> {
         info!("running initial alert check");
         if let Err(error) = self.send_alerts_once().await {
+            capture_error(&error);
             error!(%error, "error during initial alert check");
         }
 
@@ -112,6 +113,7 @@ impl App {
                         }
                         Err(error) => {
                             consecutive_errors += 1;
+                            capture_error(&error);
                             error!(%error, consecutive_errors, "error in scheduler loop");
                             let delay = scheduler_error_backoff(consecutive_errors);
                             if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
@@ -131,12 +133,28 @@ impl App {
 /// # Errors
 ///
 /// Returns an error when configuration or runtime initialization fails.
-pub async fn run(settings: Settings) -> Result<()> {
+pub fn run(settings: Settings) -> Result<()> {
     init_tracing();
     settings.log_safe();
     let _sentry_guard = init_sentry(&settings);
     info!(version = %settings.release(), "running StockCharts Alerts Bot");
-    App::new(settings)?.run_until_shutdown().await
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            let error = Error::Runtime(error);
+            capture_error(&error);
+            return Err(error);
+        }
+    };
+
+    let result = runtime.block_on(async { App::new(settings)?.run_until_shutdown().await });
+    if let Err(error) = &result {
+        capture_error(error);
+    }
+    result
 }
 
 fn scheduler_error_backoff(consecutive_errors: u64) -> TokioDuration {

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,9 +101,8 @@ impl Settings {
             known_metadata(&self.git_commit),
         ) {
             (Some(branch), Some(commit)) => Some(format!("{branch}@{commit}")),
-            (Some(branch), None) => Some(branch.to_string()),
-            (None, Some(commit)) => Some(commit.to_string()),
-            (None, None) => None,
+            (_, Some(commit)) => Some(commit.to_string()),
+            (_, None) => None,
         }
     }
 
@@ -338,6 +337,9 @@ mod tests {
         assert_eq!(settings.sentry_release().as_deref(), Some("abc123"));
 
         settings.git_commit = "unknown".to_string();
+        assert_eq!(settings.sentry_release(), None);
+
+        settings.git_branch = "main".to_string();
         assert_eq!(settings.sentry_release(), None);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,10 +80,10 @@ impl Settings {
         Ok(Self {
             minutes_between_runs: cli.minutes_between_runs,
             discord_webhook_urls,
-            sentry_dsn: cli.sentry_dsn,
-            sentry_environment: cli.sentry_environment,
-            git_commit: cli.git_commit,
-            git_branch: cli.git_branch,
+            sentry_dsn: cli.sentry_dsn.trim().to_string(),
+            sentry_environment: normalize_optional_value(&cli.sentry_environment, "production"),
+            git_commit: normalize_optional_value(&cli.git_commit, "unknown"),
+            git_branch: normalize_optional_value(&cli.git_branch, "unknown"),
         })
     }
 
@@ -91,6 +91,20 @@ impl Settings {
     #[must_use]
     pub fn release(&self) -> String {
         format!("{}@{}", self.git_branch, self.git_commit)
+    }
+
+    /// Return useful release metadata for Sentry when build metadata is known.
+    #[must_use]
+    pub fn sentry_release(&self) -> Option<String> {
+        match (
+            known_metadata(&self.git_branch),
+            known_metadata(&self.git_commit),
+        ) {
+            (Some(branch), Some(commit)) => Some(format!("{branch}@{commit}")),
+            (Some(branch), None) => Some(branch.to_string()),
+            (None, Some(commit)) => Some(commit.to_string()),
+            (None, None) => None,
+        }
     }
 
     /// Log non-secret settings with webhook URL values masked.
@@ -132,6 +146,24 @@ fn normalize_webhook_urls(urls: Vec<String>) -> Vec<String> {
         });
 
     normalized
+}
+
+fn normalize_optional_value(value: &str, default: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        default.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn known_metadata(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed == "unknown" {
+        None
+    } else {
+        Some(trimmed)
+    }
 }
 
 #[cfg(test)]
@@ -264,5 +296,48 @@ mod tests {
         .expect("settings should be valid");
 
         assert_eq!(settings.release(), "main@abc123");
+    }
+
+    #[test]
+    fn settings_trim_sentry_metadata() {
+        let mut cli = cli_with_urls(vec![WEBHOOK_URL]);
+        cli.sentry_dsn = "  https://public@example.com/1  ".to_string();
+        cli.sentry_environment = " production ".to_string();
+        cli.git_commit = " abc123 ".to_string();
+        cli.git_branch = " main ".to_string();
+
+        let settings = Settings::from_cli(cli).expect("settings should be valid");
+
+        assert_eq!(settings.sentry_dsn, "https://public@example.com/1");
+        assert_eq!(settings.sentry_environment, "production");
+        assert_eq!(settings.release(), "main@abc123");
+    }
+
+    #[test]
+    fn settings_default_empty_sentry_environment_and_metadata() {
+        let mut cli = cli_with_urls(vec![WEBHOOK_URL]);
+        cli.sentry_environment = "   ".to_string();
+        cli.git_commit = "   ".to_string();
+        cli.git_branch = "   ".to_string();
+
+        let settings = Settings::from_cli(cli).expect("settings should be valid");
+
+        assert_eq!(settings.sentry_environment, "production");
+        assert_eq!(settings.release(), "unknown@unknown");
+        assert_eq!(settings.sentry_release(), None);
+    }
+
+    #[test]
+    fn settings_sentry_release_uses_available_metadata() {
+        let mut settings =
+            Settings::from_cli(cli_with_urls(vec![WEBHOOK_URL])).expect("settings should be valid");
+
+        assert_eq!(settings.sentry_release().as_deref(), Some("main@abc123"));
+
+        settings.git_branch = "unknown".to_string();
+        assert_eq!(settings.sentry_release().as_deref(), Some("abc123"));
+
+        settings.git_commit = "unknown".to_string();
+        assert_eq!(settings.sentry_release(), None);
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -4,7 +4,7 @@ use reqwest::Client;
 use serde::Serialize;
 use tracing::{error, info};
 
-use crate::{Result, alerts::Alert, http::ensure_success_status};
+use crate::{Result, alerts::Alert, http::ensure_success_status, telemetry::capture_error};
 
 const AVATAR_URL: &str = "https://emojiguide.org/images/emoji/1/8z8e40kucdd1.png";
 
@@ -32,6 +32,7 @@ impl DiscordClient {
                     info!(webhook = index + 1, total = webhook_urls.len(), symbol = %alert.symbol, "alert sent to Discord")
                 }
                 Err(error) => {
+                    capture_error(&error);
                     error!(webhook = index + 1, total = webhook_urls.len(), symbol = %alert.symbol, %error, "Discord webhook failed")
                 }
             }
@@ -45,7 +46,7 @@ impl DiscordClient {
             .json(payload)
             .send()
             .await
-            .map_err(crate::Error::HttpClient)?;
+            .map_err(|error| crate::Error::HttpClient(error.without_url()))?;
         ensure_success_status("Discord", response.status())
     }
 }
@@ -217,5 +218,20 @@ mod tests {
 
         first.assert_async().await;
         second.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discord_request_errors_do_not_expose_webhook_urls() {
+        let error = DiscordClient::with_http_client(Client::new())
+            .send_payload(
+                "http://127.0.0.1:9/webhooks/secret-token",
+                &DiscordWebhookPayload::from_alert(&alert("Test alert", "no", "$COMPQ")),
+            )
+            .await
+            .expect_err("closed local port should fail");
+
+        let error = error.to_string();
+        assert!(!error.contains("secret-token"));
+        assert!(!error.contains("127.0.0.1"));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,9 @@ pub enum Error {
     /// StockCharts alert fetching failed.
     #[error("StockCharts error: {0}")]
     StockCharts(String),
+    /// Tokio runtime initialization failed.
+    #[error("failed to initialize Tokio runtime: {0}")]
+    Runtime(std::io::Error),
     /// Shutdown signal handling failed.
     #[error("failed to wait for shutdown signal: {0}")]
     Signal(std::io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,6 @@ use config::{Cli, Settings};
 /// # Errors
 ///
 /// Returns an error when configuration is invalid or the runtime cannot initialize.
-pub async fn run() -> Result<()> {
-    app::run(Settings::from_cli(Cli::parse())?).await
+pub fn run() -> Result<()> {
+    app::run(Settings::from_cli(Cli::parse())?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,8 @@
 
 use std::process::ExitCode;
 
-#[tokio::main]
-async fn main() -> ExitCode {
-    match stockchartsalerts::run().await {
+fn main() -> ExitCode {
+    match stockchartsalerts::run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("{error}");

--- a/src/stockcharts.rs
+++ b/src/stockcharts.rs
@@ -96,14 +96,14 @@ impl StockChartsClient {
             .header(reqwest::header::USER_AGENT, USER_AGENT)
             .send()
             .await
-            .map_err(Error::HttpClient)?;
+            .map_err(|error| Error::HttpClient(error.without_url()))?;
 
         ensure_success_status("StockCharts", response.status())?;
 
         response
             .json::<Vec<Value>>()
             .await
-            .map_err(Error::HttpClient)
+            .map_err(|error| Error::HttpClient(error.without_url()))
     }
 }
 
@@ -222,5 +222,17 @@ mod tests {
         failure.assert_async().await;
         success.assert_async().await;
         assert_eq!(alerts[0]["alert"], "Recovered");
+    }
+
+    #[tokio::test]
+    async fn fetch_alert_errors_do_not_expose_request_urls() {
+        let error = test_client("http://127.0.0.1:9/j-sum/sum?cmd=alert".to_string())
+            .fetch_alerts()
+            .await
+            .expect_err("closed local port should fail");
+
+        let error = error.to_string();
+        assert!(!error.contains("127.0.0.1"));
+        assert!(!error.contains("cmd=alert"));
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,9 +1,15 @@
 //! Logging and Sentry initialization.
 
-use sentry::ClientInitGuard;
+use std::time::Duration;
+
+use sentry::{ClientInitGuard, ClientOptions, types::Dsn};
+use tracing::warn;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
-use crate::Settings;
+use crate::{Error, Settings};
+
+const SENTRY_TRACES_SAMPLE_RATE: f32 = 0.1;
+const SENTRY_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Initialize tracing subscribers for structured runtime logs.
 pub fn init_tracing() {
@@ -18,17 +24,88 @@ pub fn init_tracing() {
 /// Initialize Sentry when a DSN is configured.
 #[must_use]
 pub fn init_sentry(settings: &Settings) -> Option<ClientInitGuard> {
-    if settings.sentry_dsn.is_empty() {
+    sentry_options(settings).map(sentry::init)
+}
+
+/// Capture an application error in Sentry when Sentry is configured.
+pub fn capture_error(error: &Error) {
+    sentry::capture_error(error);
+}
+
+fn sentry_options(settings: &Settings) -> Option<ClientOptions> {
+    Some(ClientOptions {
+        dsn: Some(parse_dsn(&settings.sentry_dsn)?),
+        environment: Some(settings.sentry_environment.clone().into()),
+        release: settings.sentry_release().map(Into::into),
+        traces_sample_rate: SENTRY_TRACES_SAMPLE_RATE,
+        shutdown_timeout: SENTRY_SHUTDOWN_TIMEOUT,
+        ..Default::default()
+    })
+}
+
+fn parse_dsn(raw_dsn: &str) -> Option<Dsn> {
+    let dsn = raw_dsn.trim();
+    if dsn.is_empty() {
         return None;
     }
 
-    Some(sentry::init((
-        settings.sentry_dsn.clone(),
-        sentry::ClientOptions {
-            environment: Some(settings.sentry_environment.clone().into()),
-            release: Some(settings.release().into()),
-            traces_sample_rate: 0.1,
-            ..Default::default()
-        },
-    )))
+    match dsn.parse() {
+        Ok(dsn) => Some(dsn),
+        Err(error) => {
+            warn!(%error, "invalid Sentry DSN, disabling Sentry");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Settings;
+
+    use super::{SENTRY_SHUTDOWN_TIMEOUT, SENTRY_TRACES_SAMPLE_RATE, parse_dsn, sentry_options};
+
+    fn settings(sentry_dsn: &str) -> Settings {
+        Settings {
+            minutes_between_runs: 5,
+            discord_webhook_urls: vec!["https://discord.example/webhook".to_string()],
+            sentry_dsn: sentry_dsn.to_string(),
+            sentry_environment: "production".to_string(),
+            git_commit: "abc123".to_string(),
+            git_branch: "main".to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_dsn_returns_none_for_missing_dsn() {
+        assert!(parse_dsn("").is_none());
+        assert!(parse_dsn("   ").is_none());
+    }
+
+    #[test]
+    fn parse_dsn_returns_none_for_invalid_dsn() {
+        assert!(parse_dsn("not a sentry dsn").is_none());
+    }
+
+    #[test]
+    fn sentry_options_include_safe_metadata() {
+        let options = sentry_options(&settings("https://public@example.com/1"))
+            .expect("valid DSN should enable Sentry");
+
+        assert!(options.dsn.is_some());
+        assert_eq!(options.environment.as_deref(), Some("production"));
+        assert_eq!(options.release.as_deref(), Some("main@abc123"));
+        assert_eq!(options.traces_sample_rate, SENTRY_TRACES_SAMPLE_RATE);
+        assert_eq!(options.shutdown_timeout, SENTRY_SHUTDOWN_TIMEOUT);
+    }
+
+    #[test]
+    fn sentry_options_omit_unknown_release() {
+        let mut settings = settings("https://public@example.com/1");
+        settings.git_commit = "unknown".to_string();
+        settings.git_branch = "unknown".to_string();
+
+        let options = sentry_options(&settings).expect("valid DSN should enable Sentry");
+
+        assert_eq!(options.release, None);
+    }
 }


### PR DESCRIPTION
## Summary

Makes Sentry startup safer and captures sanitized application errors before they leave the process.

## Changes

- Initialize Sentry before the Tokio runtime so async tasks inherit the configured hub.
- Parse and normalize Sentry config defensively, including invalid DSNs, blank environments, and unknown release metadata.
- Capture scheduler, runtime, and Discord webhook errors explicitly.
- Strip request URLs from reqwest errors before logging or sending them to Sentry.
- Update docs and regression tests for the new behavior.

## Testing

- LSP diagnostics on all modified Rust files: no diagnostics
- `cargo fmt --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked && cargo build --locked`
- Local CodeRabbit review found one minor issue; fixed in `6bec49a` and not rerun due quota discipline.