### PR TITLE
ci: enforce coverage and doc gates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,53 @@ jobs:
       - name: Run tests
         run: make test
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: 1.96.0
+          components: llvm-tools
+          rustflags: ""
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@6ed6112eb9893c58dd600eebccdf6e77ab7bfa9c # v2.79.12
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Enforce 90% line coverage
+        run: cargo llvm-cov --workspace --fail-under-lines 90 --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: 1.96.0
+          rustflags: ""
+
+      - name: Build docs
+        run: make doc
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -88,6 +135,8 @@ jobs:
       - fmt
       - clippy
       - test
+      - coverage
+      - docs
       - build
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ The scheduler runs one startup check immediately, then uses `tokio::time::interv
 
 ## Testing
 
-Run `make all` for the full local check or `make test` for tests only.
+Run `make all` for the full local check, `make test` for tests only, `make coverage` for 90% line coverage, or `make patch-coverage` for 100% changed-line coverage.
 
 ### Patterns
 
@@ -81,7 +81,9 @@ make all
 cargo fmt --check
 cargo clippy --all-targets --locked -- -D warnings
 cargo test --locked
+cargo doc --no-deps --locked
 cargo build --locked
+cargo llvm-cov --workspace --fail-under-lines 90
 ```
 
 Run locally with:
@@ -94,7 +96,7 @@ DISCORD_WEBHOOK_URLS=https://discord.example/webhook cargo run --locked
 
 GitHub Actions:
 
-1. `.github/workflows/main.yml`: Linux Rust quality gates (`fmt`, `clippy`, `test`, `build`) on Rust 1.96.0, followed by the `container` job.
+1. `.github/workflows/main.yml`: Linux Rust quality gates (`fmt`, `clippy`, `test`, `coverage`, `docs`, `build`) on Rust 1.96.0, followed by the `container` job.
 2. `.github/workflows/audit.yml`: RustSec audit on dependency file changes, manual dispatch, and a daily schedule.
 3. `container`: builds `Containerfile`, pushes `ghcr.io/major/stockchartsalerts:latest` only on `main`, then checks out `major/homehosted` and updates `apps/stockchartsalerts/helm/helmrelease.yaml` with the new image digest.
 
@@ -107,7 +109,10 @@ All actions are SHA-pinned. This repository does not publish a crate; avoid rele
 | rustfmt | `rust-toolchain.toml` | `cargo fmt --check` |
 | clippy | `.cargo/config.toml`, `Cargo.toml` | `cargo clippy --all-targets --locked -- -D warnings` |
 | cargo test | `Cargo.toml` | `cargo test --locked` |
+| cargo doc | `Makefile` | `make doc` |
 | cargo build | `Cargo.toml` | `cargo build --locked` |
+| cargo llvm-cov | `Makefile` | `make coverage` |
+| diff-cover | `Makefile` | `make patch-coverage` |
 | pre-commit | `.pre-commit-config.yaml` | auto on commit |
 | renovate | `renovate.json` | dependency updates |
 | codecov | `codecov.yaml` | coverage target |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-.PHONY: all fmt fmt-fix clippy test build audit
+.PHONY: all fmt fmt-fix clippy test doc build coverage patch-coverage audit
 
-all: fmt clippy test build
+RUSTDOCFLAGS := -D rustdoc::broken-intra-doc-links -D rustdoc::private-intra-doc-links
+PATCH_COVERAGE_BASE ?= main
+PATCH_COVERAGE_FAIL_UNDER ?= 100
+DIFF_COVER ?= diff-cover
+
+all: fmt clippy test doc build
 
 fmt:
 	cargo fmt --check
@@ -14,8 +19,18 @@ clippy:
 test:
 	cargo test --locked
 
+doc:
+	RUSTDOCFLAGS="$(RUSTDOCFLAGS)" cargo doc --no-deps --locked
+
 build:
 	cargo build --locked
+
+coverage:
+	cargo llvm-cov --workspace --fail-under-lines 90
+
+patch-coverage:
+	cargo llvm-cov --workspace --fail-under-lines 90 --lcov --output-path lcov.info
+	$(DIFF_COVER) lcov.info --compare-branch=$(PATCH_COVERAGE_BASE) --fail-under=$(PATCH_COVERAGE_FAIL_UNDER)
 
 audit:
 	cargo audit

--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ This repository uses Rust 1.96 and edition 2024.
 make all
 ```
 
-`make all` runs formatting checks, clippy with warnings denied, tests, and a locked build. Run locally with:
+`make all` runs formatting checks, clippy with warnings denied, tests, documentation checks, and a locked build. Run coverage checks with:
+
+```bash
+make coverage
+make patch-coverage
+```
+
+`make coverage` enforces 90 percent line coverage with `cargo llvm-cov`. `make patch-coverage` checks changed-line coverage against `main` with `diff-cover`; use `DIFF_COVER='uvx diff-cover'` if `diff-cover` is not installed as a standalone command. Public docstring coverage is enforced by the crate-level `#![deny(missing_docs)]` lint, and `make doc` also denies broken rustdoc links.
+
+Run locally with:
 
 ```bash
 DISCORD_WEBHOOK_URLS=https://discord.example/webhook cargo run --locked

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,9 +1,15 @@
 coverage:
-  range: 70..100
+  range: 90..100
   round: down
   precision: 1
   status:
     project:
       default:
         target: 90%
-        threshold: 0.5%
+        threshold: 0%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
+        if_ci_failed: error

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.96.0"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "llvm-tools-preview"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -228,6 +228,41 @@ mod tests {
     }
 
     #[test]
+    fn app_new_builds_shared_http_clients() {
+        let app = App::new(settings("https://discord.example/webhook".to_string()))
+            .expect("app should build shared HTTP clients");
+
+        assert_eq!(app.settings.minutes_between_runs, 5);
+    }
+
+    #[tokio::test]
+    async fn run_until_shutdown_performs_initial_check_before_waiting() {
+        let mut server = mockito::Server::new_async().await;
+        let stockcharts = server
+            .mock("GET", "/j-sum/sum")
+            .match_query(Matcher::UrlEncoded("cmd".to_string(), "alert".to_string()))
+            .with_status(200)
+            .with_body("[]")
+            .expect(1)
+            .create_async()
+            .await;
+        let http_client = Client::new();
+        let app = App::with_clients(
+            settings(format!("{}/webhooks/1/abc", server.url())),
+            StockChartsClient::with_http_client(http_client.clone())
+                .with_alerts_url(format!("{}/j-sum/sum?cmd=alert", server.url()))
+                .with_retry_delays(vec![StdDuration::ZERO, StdDuration::ZERO]),
+            DiscordClient::with_http_client(http_client),
+        );
+
+        let result =
+            tokio::time::timeout(StdDuration::from_millis(250), app.run_until_shutdown()).await;
+
+        stockcharts.assert_async().await;
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn scheduler_error_backoff_matches_python_threshold() {
         assert_eq!(scheduler_error_backoff(1), NORMAL_ERROR_BACKOFF);
         assert_eq!(scheduler_error_backoff(4), NORMAL_ERROR_BACKOFF);

--- a/src/http.rs
+++ b/src/http.rs
@@ -44,6 +44,11 @@ mod tests {
     use crate::Error;
 
     #[test]
+    fn shared_http_client_builds_successfully() {
+        let _client = super::build_http_client().expect("HTTP client should build");
+    }
+
+    #[test]
     fn success_statuses_are_accepted() {
         assert!(super::ensure_success_status("Example", StatusCode::OK).is_ok());
         assert!(super::ensure_success_status("Example", StatusCode::NO_CONTENT).is_ok());

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -108,22 +108,6 @@ mod tests {
 
         assert_eq!(options.release, None);
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::Settings;
-
-    fn settings(sentry_dsn: &str) -> Settings {
-        Settings {
-            minutes_between_runs: 5,
-            discord_webhook_urls: vec!["https://discord.example/webhook".to_string()],
-            sentry_dsn: sentry_dsn.to_string(),
-            sentry_environment: "test".to_string(),
-            git_commit: "abc123".to_string(),
-            git_branch: "main".to_string(),
-        }
-    }
 
     #[test]
     fn tracing_initialization_is_idempotent() {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -32,3 +32,37 @@ pub fn init_sentry(settings: &Settings) -> Option<ClientInitGuard> {
         },
     )))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Settings;
+
+    fn settings(sentry_dsn: &str) -> Settings {
+        Settings {
+            minutes_between_runs: 5,
+            discord_webhook_urls: vec!["https://discord.example/webhook".to_string()],
+            sentry_dsn: sentry_dsn.to_string(),
+            sentry_environment: "test".to_string(),
+            git_commit: "abc123".to_string(),
+            git_branch: "main".to_string(),
+        }
+    }
+
+    #[test]
+    fn tracing_initialization_is_idempotent() {
+        super::init_tracing();
+        super::init_tracing();
+    }
+
+    #[test]
+    fn sentry_initialization_skips_empty_dsn() {
+        assert!(super::init_sentry(&settings("")).is_none());
+    }
+
+    #[test]
+    fn sentry_initialization_returns_guard_when_configured() {
+        let guard = super::init_sentry(&settings("https://public@example.com/1"));
+
+        assert!(guard.is_some());
+    }
+}


### PR DESCRIPTION
## Summary
- Enforce 90% line coverage locally and in CI.
- Add public doc checks via `make doc` and strict rustdoc link lints, backed by the existing `#![deny(missing_docs)]` lint.
- Document the local coverage and patch coverage workflow.

## Changes
- Add Makefile targets for docs, coverage, and patch coverage.
- Add GitHub Actions coverage/docs gates and strict Codecov project/patch thresholds.
- Add focused tests for app initialization, scheduler startup polling, HTTP client construction, and telemetry initialization.

## Testing
- [x] `make all`
- [x] `make coverage`, 92.49% line coverage
- [x] `make patch-coverage DIFF_COVER='uvx diff-cover'`, 100% diff coverage
- [x] CodeRabbit local review, 0 findings

## Related
- None