### PR TITLE
fix(telemetry): use text handler for slog output

### DIFF
--- a/internal/telemetry/logging.go
+++ b/internal/telemetry/logging.go
@@ -21,14 +21,14 @@ func parseLogLevel(value string) slog.Level {
 	}
 }
 
-// InitLogging initializes the default slog logger with JSON output.
+// InitLogging initializes the default slog logger with plain text output.
 // The log level can be overridden via the LOG_LEVEL environment variable
 // (valid values: debug, info, warn, error; defaults to info).
 func InitLogging() {
 	level := parseLogLevel(os.Getenv("LOG_LEVEL"))
 
-	// Create a JSON handler writing to stdout
-	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	// Create a text handler writing to stdout
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: level,
 	})
 


### PR DESCRIPTION
Kubernetes deployments were emitting JSON log lines instead of the plain text format the previous Rust version used. Switches the slog handler from `NewJSONHandler` to `NewTextHandler` so pod logs read like `time=... level=INFO msg="..." key=value` again.

- swap `slog.NewJSONHandler` for `slog.NewTextHandler` in `internal/telemetry/logging.go`
- update the doc comment to reflect plain text output

Verified with `make all` (lint, tests, vet, build).
